### PR TITLE
GUAC-1348: Do not use MYSQL_PORT (or POSTGRES_PORT) unless their values are known to come from the user.

### DIFF
--- a/bin/start.sh
+++ b/bin/start.sh
@@ -71,8 +71,8 @@ set_property() {
 ##
 associate_mysql() {
 
-    # Use address from linked container if hostname not explicitly specified
-    if [ -z "$MYSQL_HOSTNAME" ]; then
+    # Use linked container if specified
+    if [ -n "$MYSQL_NAME" ]; then
         MYSQL_HOSTNAME="$MYSQL_PORT_3306_TCP_ADDR"
         MYSQL_PORT="$MYSQL_PORT_3306_TCP_PORT"
     fi
@@ -145,8 +145,8 @@ END
 ##
 associate_postgresql() {
 
-    # Use address from linked container if hostname not explicitly specified
-    if [ -z "$POSTGRES_HOSTNAME" ]; then
+    # Use linked container if specified
+    if [ -n "$POSTGRES_NAME" ]; then
         POSTGRES_HOSTNAME="$POSTGRES_PORT_5432_TCP_ADDR"
         POSTGRES_PORT="$POSTGRES_PORT_5432_TCP_PORT"
     fi

--- a/bin/start.sh
+++ b/bin/start.sh
@@ -74,13 +74,11 @@ associate_mysql() {
     # Use address from linked container if hostname not explicitly specified
     if [ -z "$MYSQL_HOSTNAME" ]; then
         MYSQL_HOSTNAME="$MYSQL_PORT_3306_TCP_ADDR"
+        MYSQL_PORT="$MYSQL_PORT_3306_TCP_PORT"
     fi
 
-    # Use the port from linked container if not explicitly specified, finally
-    # defaulting to the standard port of 3306
-    if [ -z "$MYSQL_PORT" ]; then
-        MYSQL_PORT="${MYSQL_PORT_3306_TCP_PORT-3306}"
-    fi
+    # Use default port if none specified
+    MYSQL_PORT="${MYSQL_PORT-3306}"
 
     # Verify required connection information is present
     if [ -z "$MYSQL_HOSTNAME" -o -z "$MYSQL_PORT" ]; then
@@ -150,13 +148,11 @@ associate_postgresql() {
     # Use address from linked container if hostname not explicitly specified
     if [ -z "$POSTGRES_HOSTNAME" ]; then
         POSTGRES_HOSTNAME="$POSTGRES_PORT_5432_TCP_ADDR"
+        POSTGRES_PORT="$POSTGRES_PORT_5432_TCP_PORT"
     fi
 
-    # Use the port from linked container if not explicitly specified, finally
-    # defaulting to the standard port of 5432
-    if [ -z "$POSTGRES_PORT" ]; then
-        POSTGRES_PORT="${POSTGRES_PORT_5432_TCP_PORT-5432}"
-    fi
+    # Use default port if none specified
+    POSTGRES_PORT="${POSTGRES_PORT-5432}"
 
     # Verify required connection information is present
     if [ -z "$POSTGRES_HOSTNAME" -o -z "$POSTGRES_PORT" ]; then


### PR DESCRIPTION
The `MYSQL_PORT` and `POSTGRES_PORT` environment variables are used by Docker to provide the hostname and port of the linked database in URL form, while we use them to provide the overridden port number when no Docker link is used. Our attempt to accomplish the latter breaks things when Docker links _are_ used, since the setup script cannot distinguish between values coming from Docker and values coming from the user.

This change _always_ uses the Docker link values for both hostname and port when the link is present. `MYSQL_HOSTNAME`, `POSTGRES_HOSTNAME`), `MYSQL_PORT`, and `POSTGRES_PORT` are only used if the Docker link is absent.
