### PR TITLE
Add Support for NoAuth Extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ How to use this image
 
 Using this image will require an existing, running Docker container with the
 [guacd image](https://registry.hub.docker.com/u/glyptodon/guacd/), and another
-Docker container providing either a PostgreSQL or MySQL database.
+Docker container providing either a PostgreSQL or MySQL database.  
+Alternatively, you can also run with authentication disabled (not recommended
+in production or untrusted environments for obvious reasons).
 
 The name of the database and all associated credentials are specified with
 environment variables given when the container is created. All other
@@ -73,7 +75,7 @@ with PostgreSQL is documented in
 [the Guacamole manual](http://guac-dev.org/doc/gug/jdbc-auth.html#jdbc-auth-postgresql).
 
 Deploying Guacamole with MySQL authentication
---------------------------------------------------
+---------------------------------------------
 
     docker run --name some-guacamole --link some-guacd:guacd \
         --link some-mysql:mysql         \
@@ -114,6 +116,51 @@ Once this script is generated, you must:
 The process for doing this via the `mysql` utility included with MySQL is
 documented in
 [the Guacamole manual](http://guac-dev.org/doc/gug/jdbc-auth.html#jdbc-auth-mysql).
+
+Deploying Guacamole with Authentication Disabled
+-------------------------------------------------
+
+    docker run --name some-guacamole --link some-guacd:guacd \
+        -e NOAUTH=1 \
+        -v /path/to/noauth-config.xml:/etc/guacamole/noauth-config.xml \
+        -d -p 8080:8080 glyptodon/guacamole
+
+Guacamole will look for configurations in the file specified by the 
+`NOAUTH_CONFIG` environment variable.  If the `NOAUTH_CONFIG` environment
+variable is not passed into the container, Guacamole will default to 
+`/etc/guacamole/noauth-config.xml` (inside the container).  Therefore,
+the configuration file must be passed as a volume in order to define the 
+connections.
+
+An example configuration for the NoAuth extension looks like:
+
+    <configs>
+        <!-- node1 connections -->
+        <config name="node1-ssh" protocol="ssh">
+            <param name="hostname" value="192.168.0.101" />
+            <param name="username" value="root" />
+            <param name="password" value="OOBER_SECURE_PASSWORD" />
+        </config>
+        <config name="node1-vnc" protocol="vnc">
+            <param name="hostname" value="192.168.0.101" />
+            <param name="port">5901</param>
+            <param name="username" value="root" />
+            <param name="password" value="OOBER_SECURE_PASSWORD" />
+        </config>
+
+        <!-- node2 connections -->
+        <config name="node2-rdp" protocol="rdp">
+            <param name="hostname" value="192.168.0.102" />
+            <param name="port" value="3389" />
+            <param name="username" value="Administrator" />
+            <param name="password" value="OOBER_SECURE_PASSWORD" />
+        </config>
+    </configs>
+
+
+More information regarding disabling authentication via the NoAuth extension
+can be found in [the Guacamole manual](http://guac-dev.org/doc/gug/noauth.html).
+
 
 Reporting issues
 ================

--- a/bin/download-extension.sh
+++ b/bin/download-extension.sh
@@ -1,3 +1,4 @@
+#!/bin/sh -e
 #
 # Copyright (C) 2015 Glyptodon LLC
 #
@@ -20,29 +21,38 @@
 # THE SOFTWARE.
 #
 
+##
+## @fn download-guacamole.sh
+##
+## Downloads Guacamole, saving the specified version to "guacamole.war" within
+## the given directory.
+##
+## @param VERSION
+##     The version of guacamole.war to download, such as "0.9.6".
+##
+## @param DESTINATION
+##     The directory to save guacamole.war within.
+##
+
+EXTENSION="$1"
+VERSION="$2"
+DESTINATION="$3"
+
 #
-# Dockerfile for guacamole-client
+# Create destination, if it does not yet exist
 #
 
-# Start from Tomcat image
-FROM tomcat:8.0.20-jre7
-MAINTAINER Michael Jumper <mike.jumper@guac-dev.org>
+mkdir -p "$DESTINATION"
 
-# Version info
-ENV \
-    GUAC_VERSION=0.9.9      \
-    GUAC_JDBC_VERSION=0.9.9
+#
+# Download extension.tar.gz, extract the .jar, and place in specified destination
+#
 
-# Add configuration scripts
-COPY bin /opt/guacamole/bin/
+echo "Downloading Guacamole Extension $EXTENSION version $VERSION to $DESTINATION ..."
+curl -L "http://downloads.sourceforge.net/project/guacamole/current/extensions/${EXTENSION}-${VERSION}.tar.gz" > "/opt/guacamole/extensions/${EXTENSION}-${VERSION}.tar.gz"
 
-# Download and install latest guacamole-client and authentication
-RUN \
-    /opt/guacamole/bin/download-guacamole.sh "$GUAC_VERSION" /usr/local/tomcat/webapps && \
-    /opt/guacamole/bin/download-jdbc-auth.sh "$GUAC_JDBC_VERSION" /opt/guacamole && \
-    /opt/guacamole/bin/download-extension.sh "guacamole-auth-noauth" "$GUAC_VERSION" /opt/guacamole/extensions
-
-# Start Guacamole under Tomcat, listening on 0.0.0.0:8080
-EXPOSE 8080
-CMD ["/opt/guacamole/bin/start.sh" ]
-
+cd /opt/guacamole/extensions
+tar -zxf ${EXTENSION}-${VERSION}.tar.gz
+mv ${EXTENSION}-${VERSION}/${EXTENSION}-${VERSION}.jar .
+rm -f ${EXTENSION}-${VERSION}.tar.gz
+cd -

--- a/bin/download-extension.sh
+++ b/bin/download-extension.sh
@@ -22,16 +22,19 @@
 #
 
 ##
-## @fn download-guacamole.sh
+## @fn download-extension.sh
 ##
-## Downloads Guacamole, saving the specified version to "guacamole.war" within
-## the given directory.
+## Downloads Guacamole extensions, extracts the .jar file, and saves it the 
+## the specified version to the given directory.
+##
+## @param EXTENSION
+##     The name of the extension to download, such as "guacamole-auth-noauth".
 ##
 ## @param VERSION
 ##     The version of guacamole.war to download, such as "0.9.6".
 ##
 ## @param DESTINATION
-##     The directory to save guacamole.war within.
+##     The directory to save the extension.jar to.
 ##
 
 EXTENSION="$1"
@@ -45,7 +48,8 @@ DESTINATION="$3"
 mkdir -p "$DESTINATION"
 
 #
-# Download extension.tar.gz, extract the .jar, and place in specified destination
+# Download extension.tar.gz, extract the .jar, and place in specified 
+# destination
 #
 
 echo "Downloading Guacamole Extension $EXTENSION version $VERSION to $DESTINATION ..."


### PR DESCRIPTION
Though disabling authentication is obviously discouraged, there are valid use cases for running without authentication.  This pull request adds an alternative to MySQL/Postgres by enabling the NoAuth extension.  
