### PR TITLE
Added redirect to /guacamole

### DIFF
--- a/bin/download-guacamole.sh
+++ b/bin/download-guacamole.sh
@@ -43,6 +43,11 @@ DESTINATION="$2"
 
 mkdir -p "$DESTINATION"
 
+ls -lh "$DESTINATION"
+rm -rf "$DESTINATION/ROOT/"
+mkdir "$DESTINATION/ROOT/"
+echo "<% response.sendRedirect(\"/guacamole\"); %>" > "$DESTINATION/ROOT/index.jsp"
+
 #
 # Download guacamole.war, placing in specified destination
 #


### PR DESCRIPTION
/ standard goes to the Dashboard of tomcat. Fixed it to redirect to /guacamole
